### PR TITLE
Add new tagmapped output type which summarises cards by tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ dependencies are:
   * requests
 
 Then copy `example_settings.py` to `settings.py` and set values to the
-API keys and tokens you can create  at 
+API keys and tokens you can create  at
 https://trello.com/docs/gettingstarted/index.html#getting-an-application-key
+
+Find other information at https://trello.com/b/cI66RoQS/trello-public-api
 
 Use
 ---

--- a/example_settings.py
+++ b/example_settings.py
@@ -7,5 +7,10 @@ KEY="MY KEY"
 SECRET="MY SECRET"
 TOKEN="MY TOKEN"
 
+# to get available boards and their IDs, fill out the credentials above
+# then run:
+#
+# > ./ptrello.py --list-boards
+#
 DEFAULT_BOARD = u'DEFAULT BOARD ID IF YOU WANT ONE'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Jinja2==2.6
 requests==0.9.0
+tablib==0.10.0

--- a/templates/board_summary.html
+++ b/templates/board_summary.html
@@ -10,6 +10,8 @@
   <link href=
   "{% block bootstrapcombinedurl %}//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css{% endblock %}"
   rel="stylesheet" type="text/css"/>
+  {% block extrajs %}
+  {% endblock %}
   <style type="text/css">
       body {
           padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
@@ -29,9 +31,6 @@
         }
         .story_name {
             font-weight: bold;
-        }
-        .checklist {
-            padding-left: 10px;
         }
         .checklist .header {
             font-weight: bold;
@@ -55,12 +54,18 @@
       <div class="container">
         <button type="button" class="btn btn-navbar" data-toggle=
         "collapse" data-target=".nav-collapse"></button> <a class=
-        "brand" href="#">User Stories: {{ title }}</a>
+        "brand" href="#">{{ title }}</a>
       </div>
     </div>
   </div>
 
   <div class="container">
+    <div class="row list_header">
+        <div class="span12">
+        {% block list_header scoped %}
+        {% endblock %}
+        </div>
+    </div>
     <ul class="nav nav-tabs" id="list_tabs">
         {% for list in lists %}
           {% set count=list.cards|length %}
@@ -77,38 +82,26 @@
             {% for card in list.cards %}
 
             <div class="row card{% if card.idShort in highlights %} highlight{% endif %}">
-              <div class="span7">
-                <div class="row story_head">
-                  <div class="span1">
+                  <div class="span2 story_head">
                     <a href="{{ card.url }}" target="_blank">Story #{{ card.idShort }}</a>
                       {% if show_labels %}
                       <div> 
                           {% for label in card.labels %}
-                          <div class="label card_tag" style="background-color: {{ label.color }}">{{ label.name|html_escape }}</div>
+                          <div class="label card_tag" style="width: 100%; background-color: {{ label.color }};">{{ label.name|html_escape }}</div>
+                          <br/>
                           {% endfor %}
                        </div>
                        {% endif %}
                   </div>
 
-                  <div class="span6 story_name">
-                    {{ card.name|html_escape }}
-                  </div>
-                </div>
+                  <div class="span5">
+                      <div class="story_name">{{ card.name|html_escape }}</div>
                 {% if card.desc %}
-                <div class="row story_description">
-                  <div class="span1">
-                    &nbsp;
-                  </div>
-
-                  <div class="span6 detail">
-                    {{ card.desc|html_escape|subst("\n","<br/>") }}
-                  </div>
-                </div>
+                {{ card.desc|html_escape|subst("\n","<br/>") }}
                 {% endif %}
               </div>
 
-              <div class="span5">
-                <div class="row checklist">
+              <div class="span5 checklist">
                   {% for checklist in card.checklists %}
 
                   <div class="header">
@@ -121,7 +114,6 @@
                       {% endfor %}
                   </div>
                   {% endfor %}
-                </div> <!-- checklist -->
               </div>
             </div><!-- row card -->
             {% if card.actions %}

--- a/templates/tagmap_standalone.html
+++ b/templates/tagmap_standalone.html
@@ -1,0 +1,56 @@
+{% extends "board_summary.html" %}
+{% block bootstrapcombinedurl %}http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css{% endblock %}
+
+{% block jqueryurl %}http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js" type="text/javascript{% endblock %}
+
+{% block bootstrapurl %}http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/js/bootstrap.min.js{% endblock %}
+
+{% block extrajs %}
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/1.0.2/Chart.min.js">  </script>
+{% endblock %}
+
+{% block list_header %}
+<span class="float:left;">
+<canvas id="myChart_aggregate" width="100" height="100" style="border-right: 1px solid black;"></canvas>
+</span>
+
+<script type="text/javascript">
+    ctx = document.getElementById("myChart_aggregate").getContext("2d");
+    data = [
+        {% for rec in lists.0.aggregate_tags %}
+        {
+            value: "{{ rec.value }}",
+            color: "{{ rec.color }}",
+            highlight: "{{ rec.highlight }}",
+            label: "{{ rec.label }}"
+        },
+        {% endfor %}
+    ];
+    options = {scaleShowLabels: false};
+    myChartAggregate = new Chart(ctx).PolarArea(data, options);
+</script>
+
+{% for list in lists %}
+    <span class="float:left">
+    <canvas id="myChart_{{ list.name|subst(" ","_")|subst("(","")|subst(")","")|subst("/","") }}" width="100" height="100"></canvas>
+    </span>
+
+    <script type="text/javascript">
+        ctx = document.getElementById("myChart_{{ list.name|subst(" ","_")|subst("(","")|subst(")","")|subst("/","") }}").getContext("2d");
+        data = [
+            {% for rec in list.cards_per_tag %}
+            {
+                value: "{{ rec.value }}",
+                color: "{{ rec.color }}",
+                highlight: "{{ rec.highlight }}",
+                label: "{{ rec.label }}"
+            },
+            {% endfor %}
+        ];
+        options = {scaleShowLabels: false};
+        myChart{{ list.name|subst(" ","_")|subst("(","")|subst(")","")|subst("/","") }} = new Chart(ctx).PolarArea(data, options);
+    </script>
+{% endfor %}
+{% endblock %}
+
+

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,3 @@
-pep8==1.4.5
-nose==1.3.0
-mock==1.0.1
+pep8
+nose
+mock


### PR DESCRIPTION
New output the same as shtml but including summary of how many stories carried each tag, for each list and once for aggregate as follows:

![tag_summary](https://cloud.githubusercontent.com/assets/94485/11541524/97c40206-992a-11e5-9bb9-d4fced0446cf.png)
